### PR TITLE
Add WordPress support.

### DIFF
--- a/function/latex2markdown.m
+++ b/function/latex2markdown.m
@@ -6,7 +6,7 @@ function mdfile = latex2markdown(filename,options)
 arguments
     filename (1,1) string
     options.outputfilename char = filename
-    options.format char {mustBeMember(options.format,{'qiita','github'})} = 'github'
+    options.format char {mustBeMember(options.format,{'qiita','github','wpquicklatex'})} = 'github'
     options.png2jpeg logical = false
     options.tableMaxWidth (1,1) double = 20
 end

--- a/function/private/processEquations.m
+++ b/function/private/processEquations.m
@@ -10,6 +10,15 @@ function str2md = processEquations(str2md, format)
 % ```math
 % equation
 % ```
+%
+% For Wordpress users: (Assume Wordpress platform renders equations via WP QuickLaTeX)
+% Add [latex] short code to the first line. 
+% Leave inline equation as it is (文中の数式は latex で $equation$ なのでそのまま)
+% and $$equation$$ will be changed to
+% [latex]
+% equation
+% [/latex]
+% See https://ja.wordpress.org/plugins/wp-quicklatex/
 
 switch format
     case 'qiita'
@@ -38,4 +47,11 @@ switch format
                 + eqncode + """/>";
             str2md = replace(str2md, "$"+parts(ii)+"$", partsMD);
         end
+case 'wpquicklatex'
+        % Add [latexpage] short code into the firstline to enable Quick LaTeX processing. 
+        str2md(1,1) = "[latexpage]" + newline + str2md(1,1);
+        % Convert the line break character from  \\ to \\\\ to take into account the de-escaping by Gutenberg editor.
+        str2md = regexprep(str2md,"\\\\", "\\\\\\\\");
+        % convert display block from  $$ ... $$ to \[ ... \]. 
+        str2md = regexprep(str2md,"[^`]?\$\$([^$]+)\$\$[^`]?",newline+"\\\\[" + newline + "$1" + newline + "\\\\]");
 end

--- a/function/private/processincludegraphics.m
+++ b/function/private/processincludegraphics.m
@@ -50,6 +50,11 @@ for ii=1:length(imageParts)
             %  ![string]('path to a image')
             imageParts(ii) = regexprep(imageParts(ii),"\\includegraphics\[[^\]]+\]{"+fileid{:}+"}",...
                 "!["+imagefilename+"]("+imagedir+imagefilename+")");
+        case 'wpquicklatex'
+            % Wordpress に移行する際は、画像ファイルを該当箇所に drag & drop する必要
+            %  ![string]('path to a image')
+            imageParts(ii) = regexprep(imageParts(ii),"\\includegraphics\[[^\]]+\]{"+fileid{:}+"}",...
+                "!["+imagefilename+"]("+imagedir+imagefilename+")");
     end
 end
 


### PR DESCRIPTION
Hi. 

Please kindly review this pull request. This pull request add a WordPress support to 
the livescript2markdown

The WordPress support is served when format = wpquicklatex. For example,

latex2markdown(sourc-filename,'format', 'wpquicklatex')

With this parameter, the latex2markdown() generates an MD source file which
is compatible with WordPress. The WordPress writer can paste this MD source
into the Gutenberg editor.

This generated MD assumes WP QuickLaTex plugin to render the LaTeX equations
( https://wordpress.org/plugins/wp-quicklatex/ ). The inline equation format
is $ ... $. And the display equation format is
\[
...\\
...\\
...
\]

In addition to the above format, the [latex] short code is embedded at the
top of the MD source file.

The figures are left as a broken link. Thus, the WordPress writer can drag and
drop the figure files to the broken file marks of the Gutenberg editor.

Note, the Enlighter seems to  ignore the language mark of the code block.

Tested versions
WordPress     : 5.4.1-ja
WP QuickLaTeX : 3.8.6
Enlighter     : 4.2
Gutenberg     : 8.1.0