### PR TITLE
Add note about nonstandard license?

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ This repository provides a functions to convert your live scripts to markdown fi
 
 I've checked the function with multiple live scripts but please note that it's not perfect. It's expected that you need some manual editing.
 
+# Licensing Note
+
+Livescript2markdown is licensed under a special MathWorks-specific variant of the BSD 2-Clause License. It contains this additional clause:
+
+```text
+* In all cases, the software is, and all modifications and derivatives of the
+  software shall be, licensed to you solely for use in conjunction with
+  MathWorks products and service offerings.
+```
+
 ## NOTE (2020/02/10)
 
 When exporting to LaTeX right after running the livescript, it's observed that the figures will be exported as eps files or not at all

--- a/license.txt
+++ b/license.txt
@@ -10,6 +10,7 @@ modification, are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
+
 * In all cases, the software is, and all modifications and derivatives of the
   software shall be, licensed to you solely for use in conjunction with
   MathWorks products and service offerings.


### PR DESCRIPTION
Hi, Michio!

It looks like livescript2markdown is licensed under a nonstandard variant of the BSD 2-Clause License which contains this additional MathWorks-specific clause:

```text
* In all cases, the software is, and all modifications and derivatives of the
  software shall be, licensed to you solely for use in conjunction with
  MathWorks products and service offerings.
```

This could cause issues in some organizational environments that have established FLOSS use policies like "Only these N standard licenses are approved" or "Only OSI-approved Open Source licenses are acceptable". Users of this library might want to be aware of that.

The license file itself looks cosmetically very similar to the BSD 3-Clause License. I didn't even notice it was actually a different license until I had been working with this library for a while.

Would you be willing to add a note about the licensing terms to the README, so it's obvious to potential users how this package is licensed?

This PR also slightly reformats the `license.txt` file to be more uniform.

Cheers,
Andrew